### PR TITLE
[SERF-2483] Use GitHub release token in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
         uses: ./
         with:
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
         uses: ./
         with:
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
         uses: ./
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
         uses: ./
         with:
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@v0.7.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             @semantic-release/changelog@6.0.2
             @semantic-release/git@10.0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
 
       - name: Send notification
         if: steps.semantic.outputs.new_release_published == 'true'


### PR DESCRIPTION
## Description
The `GITHUB_TOKEN` doesn't have sufficient permission to push the semantic release commit to the protected branch. [Link to the failed release workflow](https://github.com/scribd/job-notification/actions/runs/4785431828/jobs/8508136100).

Fix the problem by using `SCRIBD_GITHUB_RELEASE_TOKEN` which is created specifically for this use case.
<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Testing considerations
- [x] [New release](https://github.com/scribd/job-notification/releases/tag/v1.0.1) is created from [the release workflow](https://github.com/scribd/job-notification/actions/runs/4913258780/jobs/8773236416).
<!-- Describe the tests or steps that you ran to verify your changes. -->

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] ~~Updated the `README.md` as necessary~~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-2483](https://scribdjira.atlassian.net/browse/SERF-2483)
* [COREINF-5872](https://scribdjira.atlassian.net/browse/COREINF-5872)

[commit messages]: https://chris.beams.io/posts/git-commit/


[SERF-2483]: https://scribdjira.atlassian.net/browse/SERF-2483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ