### PR TITLE
feat: allow passing status as optional input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,19 @@ jobs:
           token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
           channel: test-release-notification
           repository: scribd/node-chassis
+  test-overwrite-status:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
+      - name: Run action
+        uses: ./
+        with:
+          token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
+          channel: test-release-notification
+          status: failure
 
   codeowners:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ steps:
       message: <https://github.com/${{ github.repository }}|Released update>
 ```
 
-### Overwrite repository link
+### Overwrite repository and status
 
 By default, the notification links to the repository that triggers the job. You can overwrite that using the `repository` field, which is useful for managing the release for multiple repositories in one place. See [scribd-api-proto](https://github.com/scribd/scribd-api-proto) for example.
 
@@ -59,6 +59,17 @@ steps:
       token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN }}
       channel: test-release-notification
       repository: scribd/scribd-api-ruby
+```
+Additionally, `status` can be set explicitly to `success`, `failure` or another custom value to override the default behavior of using status of the job calling this action.
+
+```yaml
+steps:
+  - name: Send notification
+    uses: scribd/job-notification@main
+    with:
+      token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN }}
+      channel: test-release-notification
+      status: warning
 ```
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: |
       Name of the repository (e.g scribd/job-notification)
       Useful for sending notifications on behalf of another repository.
-    required: true
+    required: false
     default: ${{ github.repository }}
   token:
     description: Slack token to send the notification via "gitscribd" app.
@@ -13,6 +13,10 @@ inputs:
   channel:
     description: The Slack channel name for receiving the notification
     required: true
+  status:
+    description: Customize the notification status to be "success", "failure" or a custom value.
+    required: false
+    default: ${{ job.status }}
   message:
     description: Customize the notification message.
 
@@ -24,10 +28,10 @@ runs:
       if: always()
       id: fields
       run: |
-        if [ "${{ job.status }}" = "success" ]; then
+        if [ "${{ inputs.status }}" = "success" ]; then
           echo "emoji=large_green_square" >> $GITHUB_OUTPUT
           echo "color=good" >> $GITHUB_OUTPUT
-        elif [ "${{ job.status }}" = "failure" ]; then
+        elif [ "${{ inputs.status }}" = "failure" ]; then
           echo "emoji=large_red_square" >> $GITHUB_OUTPUT
           echo "color=danger" >> $GITHUB_OUTPUT
         else
@@ -64,7 +68,7 @@ runs:
         channel-id: ${{ inputs.channel }}
         payload: |
           {
-            "text": ":${{ steps.fields.outputs.emoji }}: *Workflow <https://github.com/${{ inputs.repository }}/actions/runs/${{ github.run_id }}/|${{ github.workflow }}> ${{ job.status }}*",
+            "text": ":${{ steps.fields.outputs.emoji }}: *Workflow <https://github.com/${{ inputs.repository }}/actions/runs/${{ github.run_id }}/|${{ github.workflow }}> ${{ inputs.status }}*",
             "attachments": [
               {
                 "color": "${{ steps.fields.outputs.color }}",


### PR DESCRIPTION
This gives the flexibility to set status to something other than the immediate status of the job calling this action. For example, we want to move away from using [voxmedia/github-action-slack-notify-build](https://github.com/voxmedia/github-action-slack-notify-build) for which we already use the status input a lot based on custom criteria.

**Testing**: Per added CI test confirmed overwriting status to failure [works as expected](https://scribd.slack.com/archives/C04U68KR6CU/p1684856559193929):
<img width="611" alt="Screen Shot 2023-05-23 at 11 44 12 AM" src="https://github.com/scribd/job-notification/assets/3541764/babe103f-481c-40d0-ad02-5e2fa4d06bd3">


