### PR TITLE
bug: quote commit_message to prevent bash failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
           commit_message=$(git log --format=%B -n 1 | head -n 1)
           message="<https://github.com/${{ inputs.repository }}/commit/${{ github.sha }}|$commit_message>"
         else
-          commit_message=Link to the latest commit in the repository
+          commit_message="Link to the latest commit in the repository"
           message="<https://github.com/${{ inputs.repository }}/commit/${{ github.sha }}|$commit_message>"
         fi
         echo "message=$message" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Per this [workflow run example](https://github.com/scribd/scribd/actions/runs/5145132977/jobs/9262357103#step:3:55), assignment of a string with spaces results in failure which can be reproduced locally as well:

```
→ :~  commit_message=Link to the latest commit in the repository
-bash: to: command not found
```
Fix would be to just quote the entire sentence.