### PR TITLE
feat: allow passing environment as optional input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,19 @@ jobs:
           token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
           channel: test-release-notification
           status: failure
+  test-overwrite-environment:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
+      - name: Run action
+        uses: ./
+        with:
+          token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
+          channel: test-release-notification
+          environment: test-environment
 
   codeowners:
     runs-on: ubuntu-22.04

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Customize the notification status to be "success", "failure" or a custom value.
     required: false
     default: ${{ job.status }}
+  environment:
+    description: Customize the environment to be something other than branch name
+    required: false
+    default: ${{ github.ref_name }}
   message:
     description: Customize the notification message.
 
@@ -79,8 +83,8 @@ runs:
                     "short": true
                   },
                   {
-                    "title": "Environment",
-                    "value": "${{ github.ref_name == 'main' && 'production' || github.ref_name }}",
+                    "title": "Environment/Branch",
+                    "value": "${{ inputs.environment || github.ref_name }}",
                     "short": true
                   },
                   {


### PR DESCRIPTION
The default logic of setting environment to `production` when branch is `main` can cause confusion when the failure is not necessarily impacting the "production" environment (for example see [here](https://scribd.slack.com/archives/C5ZKWM79C/p1687286637925329)). 

Therefore I suggest to change the logic so that environment is set to branch name by default but let the caller of the action to override that and set the environment explicitly when applicable.