### PR TITLE
Update github actions due to Node 16 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: Run action
@@ -84,7 +84,7 @@ jobs:
   codeowners:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}
       - name: GitHub CODEOWNERS Validator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Send notification
       if: always()
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@v1.25.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.token }}
       with:


### PR DESCRIPTION
Update actions per https://github.com/scribd/job-notification/actions/runs/8014559004:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, slackapi/slack-github-action@v1.23.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

**Note**: could not update `gsactions/commit-message-checker@v2` since there is no new release for it to support Node 20 (per https://github.com/GsActions/commit-message-checker).