### PR TITLE
bug: single quote(') in commit_message would lead to failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
           channel: test-release-notification
-          message: <https://scribd.com|Special characters + "quotes" + `backtick`>
+          message: <https://scribd.com|Special characters + 'single quote' + "double quotes" + `backtick`>
   test-overwrite-repository:
     runs-on: ubuntu-22.04
     steps:

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ runs:
   using: composite
   steps:
     - name: Set fields
+      env:
+        input_message: ${{ inputs.message }}
+        commit_message: ${{ github.event.head_commit.message }}
       shell: bash
       if: always()
       id: fields
@@ -43,11 +46,11 @@ runs:
           echo "color=warning" >> $GITHUB_OUTPUT
         fi
 
-        if [ ! -z '${{ inputs.message }}' ]; then 
-          message='${{ inputs.message }}'
-        elif [ ! -z '${{ github.event.head_commit.message }}' ]; then 
+        if [ ! -z "$input_message" ]; then
+          message=$input_message
+        elif [ ! -z "$commit_message" ]; then
           # get commit message from `push` trigger
-          commit_message=$(echo '${{ github.event.head_commit.message }}' | head -n 1)
+          commit_message=$(echo "$commit_message" | head -n 1)
           message="<https://github.com/${{ inputs.repository }}/commit/${{ github.sha }}|$commit_message>"
         elif git rev-parse --is-inside-git-dir > /dev/null 2>&1; then  
           # get commit message from the current git directory to support `workflow_dispatch` trigger


### PR DESCRIPTION
Per [here](https://github.com/scribd/npm-packages/actions/runs/10907562072/job/30271847573#step:16:48), if commit message contains `'`, notification fails due to bash error:
```
line 16: syntax error near unexpected token `)'
```

Workaround would be to store and pass the commit_message and custom_message as an environment variable instead of github action in-place substitution (via `${{ }}`).

**Testing**: per [#test-release-notification](https://scribd.slack.com/archives/C04U68KR6CU/p1726669463528839) confirmed notification work as expected:
<img width="639" alt="Screenshot 2024-09-18 at 10 30 29 AM" src="https://github.com/user-attachments/assets/abf5b785-a976-4545-9edd-8d26cedd2852">

