### PR TITLE
test: escape commit messages fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0
 ## Maintainers
 
 Made with ❤️ by the Service Foundations teams.
+
+## Imagine we added a whole new section
+
+Just to test that a reverted commit resulting in a commit message with newlines and quotes won't break the world

--- a/README.md
+++ b/README.md
@@ -86,7 +86,3 @@ Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0
 ## Maintainers
 
 Made with ❤️ by the Service Foundations teams.
-
-## Imagine we added a whole new section
-
-Just to test that a reverted commit resulting in a commit message with newlines and quotes won't break the world

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,21 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set env (escaped)
+      id: env
+      shell: bash
+      run: |
+        {
+          echo "commit_message<<EOF"
+          echo "${{ github.event.head_commit.message }}"
+          echo "EOF"
+        } >> $GITHUB_ENV
+        {
+          echo "input_message<<EOF"
+          echo "${{ inputs.message }}"
+          echo "EOF"
+        } >> $GITHUB_ENV
     - name: Set fields
-      env:
-        input_message: ${{ inputs.message }}
-        commit_message: ${{ github.event.head_commit.message }}
       shell: bash
       if: always()
       id: fields
@@ -60,7 +71,11 @@ runs:
           commit_message="Link to the latest commit in the repository"
           message="<https://github.com/${{ inputs.repository }}/commit/${{ github.sha }}|$commit_message>"
         fi
-        echo "message=$message" >> $GITHUB_OUTPUT
+        {
+          echo "message<<EOF"
+          echo "$message"
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
 
         author=${{ github.event.pusher.name }} # context from `push` trigger
         author=${author:-${{ github.event.sender.login }}} # context from `workflow_dispatch` trigger


### PR DESCRIPTION
I created this PR just to test that revert commits containing quotes and newlines will not break the action following this fix PR https://github.com/scribd/job-notification/pull/18