### PR TITLE
chore: Rename @scribd/service-foundations to @scribd/developer-tooling in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,12 +4,12 @@
 # requests.
 #
 # Rules should follow the standard of a file matching pattern followed by a
-# team name, e.g. @scribd/service-foundations. Do not use broad teams, such as
+# team name, e.g. @scribd/developer-tooling. Do not use broad teams, such as
 # "Engineering", for code ownership.
 #
 # All lines starting with a `#` are comments and will be ignored.
 #
 # Order is important. The last matching pattern wins.
 
-# Service Foundations parent ownership
-*    @scribd/service-foundations
+# Developer Tooling parent ownership
+*    @scribd/developer-tooling


### PR DESCRIPTION
Rename `@scribd/service-foundations` to `@scribd/developer-tooling` in CODEOWNERS.

[DEVPLAT-7095](https://scribdjira.atlassian.net/browse/DEVPLAT-7095)

[DEVPLAT-7095]: https://scribdjira.atlassian.net/browse/DEVPLAT-7095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes review ownership metadata and does not affect runtime behavior or shipped code.
> 
> **Overview**
> Updates `CODEOWNERS` to replace `@scribd/service-foundations` with `@scribd/developer-tooling` as the default (`*`) code owner, including comment text reflecting the new team name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4a9454a1ff2f930e2079b0c5097b9a60ea64ec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->