### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,7 @@ name: CI
 on: [push, workflow_dispatch]
 
 jobs:
-  verify-secrets:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Verify SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC is set
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC is not set on this repository — add it to repo or org secrets before merging"
-            exit 1
-          fi
-          echo "Secret is set"
-        env:
-          TOKEN: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
-
   test:
-    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -30,7 +16,6 @@ jobs:
           token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
           channel: test-release-notification
   test-custom-message:
-    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -44,7 +29,6 @@ jobs:
           channel: test-release-notification
           message: <https://scribd.com|Custom message>
   test-custom-message-with-special-characters:
-    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -58,7 +42,6 @@ jobs:
           channel: test-release-notification
           message: <https://scribd.com|Special characters + 'single quote' + "double quotes" + `backtick`>
   test-overwrite-repository:
-    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -72,7 +55,6 @@ jobs:
           channel: test-release-notification
           repository: scribd/node-chassis
   test-overwrite-status:
-    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -86,7 +68,6 @@ jobs:
           channel: test-release-notification
           status: failure
   test-overwrite-environment:
-    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,21 @@ name: CI
 on: [push, workflow_dispatch]
 
 jobs:
+  verify-secrets:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Verify SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC is set
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC is not set on this repository — add it to repo or org secrets before merging"
+            exit 1
+          fi
+          echo "Secret is set"
+        env:
+          TOKEN: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
+
   test:
+    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -16,6 +30,7 @@ jobs:
           token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
           channel: test-release-notification
   test-custom-message:
+    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -29,6 +44,7 @@ jobs:
           channel: test-release-notification
           message: <https://scribd.com|Custom message>
   test-custom-message-with-special-characters:
+    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -42,6 +58,7 @@ jobs:
           channel: test-release-notification
           message: <https://scribd.com|Special characters + 'single quote' + "double quotes" + `backtick`>
   test-overwrite-repository:
+    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -55,6 +72,7 @@ jobs:
           channel: test-release-notification
           repository: scribd/node-chassis
   test-overwrite-status:
+    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -68,6 +86,7 @@ jobs:
           channel: test-release-notification
           status: failure
   test-overwrite-environment:
+    needs: verify-secrets
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,9 @@ jobs:
 
       - name: Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v5
         with:
+          semantic_version: 24
           extra_plugins: |
             @semantic-release/changelog@6.0.2
             @semantic-release/git@10.0.1

--- a/action.yml
+++ b/action.yml
@@ -68,13 +68,14 @@ runs:
 
     - name: Send notification
       if: always()
-      uses: slackapi/slack-github-action@v1.25.0
+      uses: slackapi/slack-github-action@v3
       env:
         SLACK_BOT_TOKEN: ${{ inputs.token }}
       with:
-        channel-id: ${{ inputs.channel }}
+        method: chat.postMessage
         payload: |
           {
+            "channel": "${{ inputs.channel }}",
             "text": ":${{ steps.fields.outputs.emoji }}: *Workflow <https://github.com/${{ inputs.repository }}/actions/runs/${{ github.run_id }}/|${{ github.workflow }}> ${{ inputs.status }}*",
             "attachments": [
               {

--- a/action.yml
+++ b/action.yml
@@ -69,10 +69,9 @@ runs:
     - name: Send notification
       if: always()
       uses: slackapi/slack-github-action@v3
-      env:
-        SLACK_BOT_TOKEN: ${{ inputs.token }}
       with:
         method: chat.postMessage
+        token: ${{ inputs.token }}
         payload: |
           {
             "channel": "${{ inputs.channel }}",


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `cycjimmy/semantic-release-action@v4` → `cycjimmy/semantic-release-action@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release automation (`semantic-release`) and Slack notification delivery; misconfiguration could break publishing or notifications.
> 
> **Overview**
> Modernizes CI automation to avoid deprecated Node.js 20 GitHub Actions runtimes.
> 
> The release workflow upgrades `cycjimmy/semantic-release-action` to `v5` and explicitly sets `semantic_version: 24`.
> 
> The composite `job-notification` action upgrades `slackapi/slack-github-action` to `v3` and updates invocation to the new API (`method: chat.postMessage`, `token`/`payload` usage, and embedding `channel` in the payload instead of `channel-id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66a86b66caa77603e529dd814aedc747ea0a6e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->