### PR TITLE
fix: DEVPLAT-7883 prevent shell injection in Set fields step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,14 +31,18 @@ runs:
       env:
         input_message: ${{ inputs.message }}
         commit_message: ${{ github.event.head_commit.message }}
+        status: ${{ inputs.status }}
+        repository: ${{ inputs.repository }}
+        event_pusher_name: ${{ github.event.pusher.name }}
+        event_sender_login: ${{ github.event.sender.login }}
       shell: bash
       if: always()
       id: fields
       run: |
-        if [ "${{ inputs.status }}" = "success" ]; then
+        if [ "$status" = "success" ]; then
           echo "emoji=large_green_square" >> $GITHUB_OUTPUT
           echo "color=good" >> $GITHUB_OUTPUT
-        elif [ "${{ inputs.status }}" = "failure" ]; then
+        elif [ "$status" = "failure" ]; then
           echo "emoji=large_red_square" >> $GITHUB_OUTPUT
           echo "color=danger" >> $GITHUB_OUTPUT
         else
@@ -47,23 +51,23 @@ runs:
         fi
 
         if [ ! -z "$input_message" ]; then
-          message=$input_message
+          message="$input_message"
         elif [ ! -z "$commit_message" ]; then
           # get commit message from `push` trigger
           commit_message=$(echo "$commit_message" | head -n 1)
-          message="<https://github.com/${{ inputs.repository }}/commit/${{ github.sha }}|$commit_message>"
-        elif git rev-parse --is-inside-git-dir > /dev/null 2>&1; then  
+          message="<https://github.com/$repository/commit/$GITHUB_SHA|$commit_message>"
+        elif git rev-parse --is-inside-git-dir > /dev/null 2>&1; then
           # get commit message from the current git directory to support `workflow_dispatch` trigger
           commit_message=$(git log --format=%B -n 1 | head -n 1)
-          message="<https://github.com/${{ inputs.repository }}/commit/${{ github.sha }}|$commit_message>"
+          message="<https://github.com/$repository/commit/$GITHUB_SHA|$commit_message>"
         else
           commit_message="Link to the latest commit in the repository"
-          message="<https://github.com/${{ inputs.repository }}/commit/${{ github.sha }}|$commit_message>"
+          message="<https://github.com/$repository/commit/$GITHUB_SHA|$commit_message>"
         fi
         echo "message=$message" >> $GITHUB_OUTPUT
 
-        author=${{ github.event.pusher.name }} # context from `push` trigger
-        author=${author:-${{ github.event.sender.login }}} # context from `workflow_dispatch` trigger
+        author="$event_pusher_name"               # context from `push` trigger
+        author="${author:-$event_sender_login}"   # context from `workflow_dispatch` trigger
         echo "author=$author" >> $GITHUB_OUTPUT
 
     - name: Send notification


### PR DESCRIPTION
## Summary

Resolves [DEVPLAT-7883](https://scribdjira.atlassian.net/browse/DEVPLAT-7883) — Semgrep finding of `yaml.github-actions.security.run-shell-injection` in the "Set fields" step.

Moves all `${{ github.* }}` and `${{ inputs.* }}` interpolations out of the `run:` shell block into the step-level `env:` block, then references them as quoted shell variables. Uses the runner-provided `$GITHUB_SHA` instead of redeclaring `github.sha`.

## Variables moved into `env:`

- `status: ${{ inputs.status }}`
- `repository: ${{ inputs.repository }}`
- `event_pusher_name: ${{ github.event.pusher.name }}`
- `event_sender_login: ${{ github.event.sender.login }}`

(`input_message` and `commit_message` were already done correctly.)

## Notes

- No behavior change — same emoji/color logic, same URL format, same author fallback (`${author:-$event_sender_login}` in bash works the same as `${author:-${{ github.event.sender.login }}}` after the template substitution).
- Added quoting (`"$input_message"`, `"${author:-$event_sender_login}"`) where the original was unquoted; safe because none of these values can legitimately contain spaces or shell metachars.
- YAML validity verified.

## Test plan

- [ ] Trigger a workflow that uses this action on a `push` event — verify Slack notification has the right emoji, color, author, and commit-link
- [ ] Trigger via `workflow_dispatch` — verify author falls back to `sender.login` and commit message is pulled from `git log`
- [ ] Trigger via failure path (e.g. failing test) — verify red emoji + danger color

References:
- [Semgrep rule](https://semgrep.dev/r/yaml.github-actions.security.run-shell-injection.run-shell-injection)
- [GitHub Actions security hardening](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7883]: https://scribdjira.atlassian.net/browse/DEVPLAT-7883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to how the composite action passes GitHub/inputs values into the bash script (via `env` + quoting), intended to reduce shell-injection risk while keeping notification behavior the same.
> 
> **Overview**
> Hardens the `Set fields` bash step in `action.yml` by moving `${{ inputs.* }}`/`${{ github.* }}` interpolations into step-level `env` variables and referencing them as quoted shell variables.
> 
> Commit-link construction is updated to use `$GITHUB_SHA` and `$repository`, and author selection now uses `$event_pusher_name` with a `$event_sender_login` fallback, reducing exposure to run-script injection without changing the Slack payload structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687700ab5d7ebd2b1b00ce8ddfc2632b3ba86a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->